### PR TITLE
fix: add install of uv to release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
 
           printf '%s\n' "Verified upstream branch has not changed, continuing with release..."
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Action | Semantic Version Release
         id: release
         # Adjust tag with desired version if applicable.


### PR DESCRIPTION
Required as it is used as build command in python-semantic-release