### PR TITLE
feat: Add jmespath functions key_values and first

### DIFF
--- a/src/json_assertion/testing.py
+++ b/src/json_assertion/testing.py
@@ -25,6 +25,16 @@ class _ExtendedFunctions(Functions):
     def _func_all(self, array: list[Any]) -> bool:
         return all(array)
 
+    @signature({"types": ["object"]})
+    def _func_key_values(self, obj: dict[str, Any]) -> list[dict[str, Any]]:
+        return [{"key": k, "value": v} for k, v in obj.items()]
+
+    @signature({"types": ["array"]})
+    def _func_first(self, array: list[Any]) -> Any:
+        if not array:
+            return None
+        return array[0]
+
 
 def json_assert_that(
     json_data_document: Any,

--- a/tests/test_json_assert_that_raises.py
+++ b/tests/test_json_assert_that_raises.py
@@ -52,6 +52,12 @@ cases: Final[list[Case]] = [
         raised_type=ValueError,
         content_match="Error processing JMESPath expression",
     ),
+    Case(
+        name="extended_functions_first_non_array",
+        expression="first(long_string)",
+        raised_type=ValueError,
+        content_match="Invalid JMESPath expression",
+    ),
 ]
 
 

--- a/tests/test_json_assert_that_with_predicate_possitive.py
+++ b/tests/test_json_assert_that_with_predicate_possitive.py
@@ -67,6 +67,24 @@ cases: Final[list[Case]] = [
         ],
         expected_result=False,
     ),
+    Case(
+        name="extended_functions_key_values_and_first",
+        expression="length(first(key_values(@)[?starts_with(key, 'any')].value))",
+        predicate=lambda v: v == 3,
+        expected_result=True,
+    ),
+    Case(
+        name="extended_functions_first_empty_list",
+        expression="first(any_field[2])",
+        predicate=lambda v: v is None,
+        expected_result=True,
+    ),
+    Case(
+        name="extended_functions_first_non_empty_list",
+        expression="first(first(any_field))",
+        predicate=lambda v: v == True,  # noqa: E712
+        expected_result=True,
+    ),
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "json-assertion"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "jmespath" },


### PR DESCRIPTION
- key_values will convert a dictionary to a list of dicts containing 'key' and 'value' field This is required eg to be able to select a key out of a dictionary containing a certain prefix. (see one of the added tests as example)
- first will select first element of an array, or return None. if not an array, standard JMESPath expression invalid is raised.